### PR TITLE
Prepare for 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add a build script to build releases for each target
+- Add Linux (musl) installation instructions
+
+### Changed
+- Update add entry functionality to also stage the change entry in the git index for committing
+
+### Fixed
+- Fix error when piping the output of `cl`
 
 ## [0.4.0] - 2019-10-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.0] - 2019-10-11
 ### Added
 - Add a build script to build releases for each target
 - Add Linux (musl) installation instructions
 
 ### Changed
-- Update add entry functionality to also stage the change entry in the git index for committing
+- Update add entry functionality to also stage the change entry in the git
+  index for committing
 
 ### Fixed
 - Fix error when piping the output of `cl`
@@ -38,7 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial implementation of `cl` binary
 
-[Unreleased]: https://github.com/marcaddeo/cl/compare/0.4.0...HEAD
+[Unreleased]: https://github.com/marcaddeo/cl/compare/0.5.0...HEAD
+[0.5.0]: https://github.com/marcaddeo/cl/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/marcaddeo/cl/compare/0.3.0...0.4.0
 [0.3.0]: https://github.com/marcaddeo/cl/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/marcaddeo/cl/compare/0.1.0...0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cl"
-version = "0.4.0"
+version = "0.5.0"
 description = "A command line tool for recording changes to be collected for use in a Keep A Changelog formatted CHANGELOG.md"
 authors = ["Marc Addeo <hi@marc.cx>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ $ brew install marcaddeo/clsuite/cl
 
 ## Debian
 ```
-$ curl -LO https://github.com/marcaddeo/cl/releases/download/0.4.0/cl_0.4.0_amd64.deb
-$ sudo dpkg -i cl_0.4.0_amd64.deb
+$ curl -LO https://github.com/marcaddeo/cl/releases/download/0.5.0/cl_0.5.0_amd64.deb
+$ sudo dpkg -i cl_0.5.0_amd64.deb
 ```
 
 ### Linux
 ```
-$ curl -LO https://github.com/marcaddeo/cl/releases/download/0.4.0/cl-0.4.0-x86_64-unknown-linux-musl.tar.gz
-$ tar czvf cl-0.4.0-x86_64-unknown-linux-musl.tar.gz
+$ curl -LO https://github.com/marcaddeo/cl/releases/download/0.5.0/cl-0.5.0-x86_64-unknown-linux-musl.tar.gz
+$ tar czvf cl-0.5.0-x86_64-unknown-linux-musl.tar.gz
 $ sudo mv cl /usr/local/bin/cl
 ```
 
@@ -35,7 +35,7 @@ $ cargo install --git https://github.com/marcaddeo/cl
 
 ## Usage
 ```
-cl 0.4.0
+cl 0.5.0
 Marc Addeo <hi@marc.cx>
 A command line tool for recording changes to be collected for use in a Keep A Changelog formatted CHANGELOG.md
 


### PR DESCRIPTION

## [0.5.0] - 2019-10-11
### Added
- Add a build script to build releases for each target
- Add Linux (musl) installation instructions

### Changed
- Update add entry functionality to also stage the change entry in the git
  index for committing

### Fixed
- Fix error when piping the output of `cl`


[Unreleased]: https://github.com/marcaddeo/cl/compare/0.5.0...HEAD
[0.5.0]: https://github.com/marcaddeo/cl/compare/0.4.0...0.5.0
[0.4.0]: https://github.com/marcaddeo/cl/compare/0.3.0...0.4.0
[0.3.0]: https://github.com/marcaddeo/cl/compare/0.2.0...0.3.0
[0.2.0]: https://github.com/marcaddeo/cl/compare/0.1.0...0.2.0
[0.1.0]: https://github.com/marcadde/cl/releases/tag/0.1.0