### PR TITLE
Fix error with branches that use a directory separator

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -217,8 +217,8 @@ fn get_cl_path() -> Result<PathBuf> {
     let head = head.shorthand().ok_or(ClError::CouldNotDetermineHead)?;
     let mut cl_path = get_cl_dir()?;
 
-    create_dir_all(cl_path.clone())?;
     cl_path.push(head);
+    create_dir_all(cl_path.clone())?;
     cl_path.set_extension("yml");
 
     Ok(cl_path)


### PR DESCRIPTION
When running `cl added test` on a branch called `test/branch`, `cl`
would throw an error because it was not creating the `.cl/test`
directory before trying to write to `.cl/test/branch.yml`. This fixes
that.

Closes #6 