### PR TITLE
Prepare CHANGELOG for 0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.9.0] - 2020-07-28
 ### Added
 - Add an aggregate subcommand to aggregate change entries into the CHANGELOG.md
   file
@@ -68,7 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial implementation of `cl` binary
 
-[Unreleased]: https://github.com/marcaddeo/cl/compare/0.8.0...HEAD
+[Unreleased]: https://github.com/marcaddeo/cl/compare/0.9.0...HEAD
+[0.9.0]: https://github.com/marcaddeo/cl/compare/0.8.0...0.9.0
 [0.8.0]: https://github.com/marcaddeo/cl/compare/0.7.0...0.8.0
 [0.7.0]: https://github.com/marcaddeo/cl/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/marcaddeo/cl/compare/0.5.0...0.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "cl"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cl"
-version = "0.8.0"
+version = "0.9.0"
 description = "A command line tool for recording changes to be collected for use in a Keep A Changelog formatted CHANGELOG.md"
 keywords = ["changelog", "manager", "keepachangelog"]
 categories = ["command-line-utilities", "development-tools", "text-processing"]

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ $ brew install marcaddeo/clsuite/cl
 
 ### Debian
 ```
-$ curl -LO https://github.com/marcaddeo/cl/releases/download/0.8.0/cl_0.8.0_amd64.deb
-$ sudo dpkg -i cl_0.8.0_amd64.deb
+$ curl -LO https://github.com/marcaddeo/cl/releases/download/0.9.0/cl_0.9.0_amd64.deb
+$ sudo dpkg -i cl_0.9.0_amd64.deb
 ```
 
 ### Linux
 ```
-$ curl -LO https://github.com/marcaddeo/cl/releases/download/0.8.0/cl-0.8.0-x86_64-unknown-linux-musl.tar.gz
-$ tar czvf cl-0.8.0-x86_64-unknown-linux-musl.tar.gz
+$ curl -LO https://github.com/marcaddeo/cl/releases/download/0.9.0/cl-0.9.0-x86_64-unknown-linux-musl.tar.gz
+$ tar czvf cl-0.9.0-x86_64-unknown-linux-musl.tar.gz
 $ sudo mv cl /usr/local/bin/cl
 ```
 
@@ -35,7 +35,7 @@ $ cargo install cl
 
 ## Usage
 ```
-cl 0.8.0
+cl 0.9.0
 Marc Addeo <hi@marc.cx>
 A command line tool for recording changes to be collected for use in a Keep A Changelog formatted CHANGELOG.md
 


### PR DESCRIPTION


## [0.9.0] - 2020-07-28
### Added
- Add an aggregate subcommand to aggregate change entries into the CHANGELOG.md
  file

### Fixed
- Fix bug that caused cl entries to be not properly nested in their branch
  directories

[Unreleased]: https://github.com/marcaddeo/cl/compare/0.9.0...HEAD
[0.9.0]: https://github.com/marcaddeo/cl/compare/0.8.0...0.9.0
[0.8.0]: https://github.com/marcaddeo/cl/compare/0.7.0...0.8.0
[0.7.0]: https://github.com/marcaddeo/cl/compare/0.6.0...0.7.0
[0.6.0]: https://github.com/marcaddeo/cl/compare/0.5.0...0.6.0
[0.5.0]: https://github.com/marcaddeo/cl/compare/0.4.0...0.5.0
[0.4.0]: https://github.com/marcaddeo/cl/compare/0.3.0...0.4.0
[0.3.0]: https://github.com/marcaddeo/cl/compare/0.2.0...0.3.0
[0.2.0]: https://github.com/marcaddeo/cl/compare/0.1.0...0.2.0
[0.1.0]: https://github.com/marcadde/cl/releases/tag/0.1.0
